### PR TITLE
Improve handling of `...` in `uses_labels()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ License: MIT + file LICENSE
 URL: https://github.com/rstudio/ggcheck
 BugReports: https://github.com/rstudio/ggcheck/issues
 Imports: 
+    purrr,
     rlang
 Suggests: 
     ggplot2,

--- a/R/labels.R
+++ b/R/labels.R
@@ -104,8 +104,8 @@ uses_labels <- function(p, ...) {
 
   null_expected          <- lengths(args) == 0
   result[null_expected]  <- lengths(labels[null_expected]) == 0
-  result[!null_expected] <- as.logical(
-    Map(identical, args[!null_expected], labels[!null_expected])
+  result[!null_expected] <- purrr::map2_lgl(
+    args[!null_expected], labels[!null_expected], identical
   )
 
   names(result) <- names(args)

--- a/R/labels.R
+++ b/R/labels.R
@@ -50,8 +50,7 @@ get_labels <- function(p, aes = NULL) {
 #'   Each argument should have a name matching a [ggplot][ggplot2::ggplot]
 #'   [aesthetic][ggplot2::aes] and a value matching the expected label.
 #'
-#' @return [`TRUE`], if all labels match arguments to `...`, or [`FALSE`] if at
-#'   least one label does not match
+#' @return A logical vector of the same length as the number of inputs to `...`.
 #'
 #' @family functions for checking labels
 #' @export
@@ -93,13 +92,16 @@ uses_labels <- function(p, ...) {
 
   labels <- get_labels(p, names(args))
 
-  null_expected <- lengths(args) == 0
-  nulls_match   <- all(lengths(labels[null_expected]) == 0)
-  strings_match <- all(
-    mapply(identical, args[!null_expected], labels[!null_expected])
+  result <- logical(length(args))
+
+  null_expected          <- lengths(args) == 0
+  result[null_expected]  <- lengths(labels[null_expected]) == 0
+  result[!null_expected] <- as.logical(
+    Map(identical, args[!null_expected], labels[!null_expected])
   )
 
-  strings_match && nulls_match
+  names(result) <- names(args)
+  result
 }
 
 is_scalar_string_or_null <- function(x) {

--- a/R/labels.R
+++ b/R/labels.R
@@ -46,9 +46,11 @@ get_labels <- function(p, aes = NULL) {
 #' [`NULL`] ***or*** if a requested aesthetic is not present in the plot.
 #'
 #' @param p A ggplot object
-#' @param ... Named [character] strings.
+#' @param ... <[`dynamic-dots`][rlang::dyn-dots]> Named [character] strings.
 #'   Each argument should have a name matching a [ggplot][ggplot2::ggplot]
-#'   [aesthetic][ggplot2::aes] and a value matching the expected label.
+#'   [aesthetic][ggplot2::aes] or [label][ggplot2::labs],
+#'   and a value matching the expected label.
+#'   Named character strings may be passed as arguments or as list elements.
 #'
 #' @return A logical vector of the same length as the number of inputs to `...`.
 #'
@@ -69,8 +71,14 @@ get_labels <- function(p, aes = NULL) {
 #' # The colo(u)r aesthetic can be matched with or without a u
 #' uses_labels(p, color = NULL)
 #' uses_labels(p, colour = NULL)
+#'
+#' # Inputs can be passed from a list, with or without the !!! operator
+#' label_list <- list(x = "Weight", y = "MPG", color = NULL)
+#' uses_labels(p, label_list)
+#' uses_labels(p, !!!label_list)
 uses_labels <- function(p, ...) {
-  args <- list(...)
+  args <- rlang::flatten(rlang::dots_list(...))
+  args <- rlang::dots_list(!!!args, .homonyms = "error")
 
   if (length(args) == 0) {
     stop(

--- a/man/uses_labels.Rd
+++ b/man/uses_labels.Rd
@@ -14,8 +14,7 @@ Each argument should have a name matching a \link[ggplot2:ggplot]{ggplot}
 \link[ggplot2:aes]{aesthetic} and a value matching the expected label.}
 }
 \value{
-\code{\link{TRUE}}, if all labels match arguments to \code{...}, or \code{\link{FALSE}} if at
-least one label does not match
+A logical vector of the same length as the number of inputs to \code{...}.
 }
 \description{
 \code{uses_labels()} tests whether a plot uses one or more \link[ggplot2:labs]{labels}.

--- a/man/uses_labels.Rd
+++ b/man/uses_labels.Rd
@@ -9,9 +9,11 @@ uses_labels(p, ...)
 \arguments{
 \item{p}{A ggplot object}
 
-\item{...}{Named \link{character} strings.
+\item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> Named \link{character} strings.
 Each argument should have a name matching a \link[ggplot2:ggplot]{ggplot}
-\link[ggplot2:aes]{aesthetic} and a value matching the expected label.}
+\link[ggplot2:aes]{aesthetic} or \link[ggplot2:labs]{label},
+and a value matching the expected label.
+Named character strings may be passed as arguments or as list elements.}
 }
 \value{
 A logical vector of the same length as the number of inputs to \code{...}.
@@ -37,6 +39,11 @@ uses_labels(p, x = "Weight", y = "MPG", color = NULL)
 # The colo(u)r aesthetic can be matched with or without a u
 uses_labels(p, color = NULL)
 uses_labels(p, colour = NULL)
+
+# Inputs can be passed from a list, with or without the !!! operator
+label_list <- list(x = "Weight", y = "MPG", color = NULL)
+uses_labels(p, label_list)
+uses_labels(p, !!!label_list)
 }
 \seealso{
 Other functions for checking labels: 

--- a/tests/testthat/test-labels.R
+++ b/tests/testthat/test-labels.R
@@ -49,19 +49,22 @@ test_that("Identifies labels", {
 })
 
 test_that("Checks whether a label is used", {
-  expect_true(uses_labels(p, x = "X"))
-  expect_true(uses_labels(p, x = "X", y = "Y"))
+  expect_equal(uses_labels(p, x = "X"),          c(x = TRUE))
+  expect_equal(uses_labels(p, x = "X", y = "Y"), c(x = TRUE, y = TRUE))
 
-  expect_true(uses_labels(p, color = NULL))
-  expect_true(uses_labels(p, fill = NULL))
-  expect_true(uses_labels(p, color = character(0)))
-  expect_true(uses_labels(p, fill = character(0)))
+  expect_equal(uses_labels(p, color = NULL),         c(color = TRUE))
+  expect_equal(uses_labels(p, fill  = NULL),         c(fill  = TRUE))
+  expect_equal(uses_labels(p, color = character(0)), c(color = TRUE))
+  expect_equal(uses_labels(p, fill  = character(0)), c(fill  = TRUE))
 
-  expect_true(uses_labels(p, x = "X", y = "Y", color = NULL))
+  expect_equal(
+    uses_labels(p, x = "X", y = "Y", color = NULL),
+    c(x = TRUE, y = TRUE, color = TRUE)
+  )
 
-  expect_false(uses_labels(p, x = "Incorrect"))
-  expect_false(uses_labels(p, x = "X", y = "Incorrect"))
-  expect_false(uses_labels(p, fill = "Incorrect"))
+  expect_equal(uses_labels(p, x = "Incorrect"), c(x = FALSE))
+  expect_equal(uses_labels(p, x = "X", y = "Incorrect"), c(x = TRUE, y = FALSE))
+  expect_equal(uses_labels(p, fill = "Incorrect"), c(fill = FALSE))
 })
 
 test_that("Throws a grading error when label is not a string or NULL", {

--- a/tests/testthat/test-labels.R
+++ b/tests/testthat/test-labels.R
@@ -67,6 +67,31 @@ test_that("Checks whether a label is used", {
   expect_equal(uses_labels(p, fill = "Incorrect"), c(fill = FALSE))
 })
 
+test_that("Inputs from list", {
+  expect_equal(
+    uses_labels(p, list(x = "X", y = "Y", color = "C")),
+    c(x = TRUE, y = TRUE, color = FALSE)
+  )
+  expect_equal(
+    uses_labels(p, x = "X", list(y = "Y", color = "C")),
+    c(x = TRUE, y = TRUE, color = FALSE)
+  )
+
+  expect_equal(
+    uses_labels(p, !!!list(x = "X", y = "Y", color = "C")),
+    c(x = TRUE, y = TRUE, color = FALSE)
+  )
+  expect_equal(
+    uses_labels(p, x = "X", !!!list(y = "Y", color = "C")),
+    c(x = TRUE, y = TRUE, color = FALSE)
+  )
+
+  expect_equal(
+    uses_labels(p, x = "X", list(y = "Y"), !!!list(color = "C")),
+    c(x = TRUE, y = TRUE, color = FALSE)
+  )
+})
+
 test_that("Throws a grading error when label is not a string or NULL", {
   expect_error(uses_labels(p, x = c("X", "Y")))
   expect_error(uses_labels(p, x = 1))
@@ -77,4 +102,13 @@ test_that("Throws a grading error when argument is not named", {
   expect_error(uses_labels(p, "X"))
   expect_error(uses_labels(p, c(x = "X", y = "Y")))
   expect_error(uses_labels(p))
+})
+
+test_that("Throws a grading error when name is duplicated", {
+  expect_error(uses_labels(p, x = "X", x = "X"))
+  expect_error(uses_labels(p, x = "X", list(x = "X", y = "Y")))
+  expect_error(uses_labels(p, x = "X", !!!list(x = "X", y = "Y")))
+  expect_error(uses_labels(p, list(x = "X"), list(x = "X", y = "Y")))
+  expect_error(uses_labels(p, list(x = "X"), !!!list(x = "X", y = "Y")))
+  expect_error(uses_labels(p, !!!list(x = "X"), !!!list(x = "X", y = "Y")))
 })


### PR DESCRIPTION
This PR makes two major updates to `uses_labels()`:

- `uses_labels()` now returns a named logical vector instead of a single logical value

``` r
library(ggcheck)
library(ggplot2)

p <- ggplot(mpg, aes(x = displ, y = hwy, color = class)) +
  labs(x = "Weight", y = "MPG", color = NULL)

uses_labels(p, x = "Weight", y = "MPG", color = NULL)
#>     x     y color 
#>  TRUE  TRUE  TRUE
```

<sup>Created on 2021-11-23 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

- `uses_labels()` now splices lists of arguments, with or without the `!!!` operator

``` r
library(ggcheck)
library(ggplot2)

p <- ggplot(mpg, aes(x = displ, y = hwy, color = class)) +
  labs(x = "Weight", y = "MPG", color = NULL)

label_list <- list(y = "MPG", color = NULL)

uses_labels(p, x = "Weight", label_list)
#>     x     y color 
#>  TRUE  TRUE  TRUE

uses_labels(p, x = "Weight", !!!label_list)
#>     x     y color 
#>  TRUE  TRUE  TRUE
```

<sup>Created on 2021-11-23 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #25.