### PR TITLE
Fix bug when `fail_if_not_ggplot()` attempts to access a `gradethis` `.result` object 

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,18 +1,14 @@
-# NOTE: This workflow is overkill for most R packages
-# check-standard.yaml is likely a better choice
-# usethis::use_github_action("check-standard") will install it.
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 #
-# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
-# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
+# NOTE: This workflow is overkill for most R packages and
+# check-standard.yaml is likely a better choice.
+# usethis::use_github_action("check-standard") will install it.
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
-      - master
+    branches: [main, master]
 
 name: R-CMD-check
 
@@ -27,8 +23,12 @@ jobs:
       matrix:
         config:
           - {os: macOS-latest,   r: 'release'}
+
           - {os: windows-latest, r: 'release'}
+          # Use 3.6 to trigger usage of RTools35
           - {os: windows-latest, r: '3.6'}
+
+          # Use older ubuntu to maximise backward compatibility
           - {os: ubuntu-18.04,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-18.04,   r: 'release'}
           - {os: ubuntu-18.04,   r: 'oldrel-1'}
@@ -43,41 +43,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
-        id: install-r
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Install devel system dependencies
-        if: matrix.config.os == 'ubuntu-18.04' && matrix.config.r == 'devel'
-        run: sudo apt-get install -y libcurl4-openssl-dev
-
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          cache-version: 1
-          extra-packages: rcmdcheck
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - uses: r-lib/actions/check-r-package@v1
-
-      - name: Show testthat output
-        if: always()
-        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
-        shell: bash
-
-      - name: Code coverage
-        if: matrix.config.os == 'ubuntu-18.04' && matrix.config.r == 'release'
-        shell: Rscript {0}
-        run: |
-          pak::pkg_install("covr")
-          covr::codecov()
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ matrix.config.os }}-r${{ matrix.config.r }}-results
-          path: check
+          upload-snapshots: true

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,61 +1,46 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-     - main
-     - master
-     - rc-**
-     - pkgdown/**
+    branches: [main, master]
   pull_request:
-    branches:
-     - main
-     - master
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
 
 name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
-      RSPM: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
-        id: install-r
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          extra-packages: any::pkgdown, local::.
           needs: website
 
-      - name: Build Site
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
-        run: |
-          pkgdown::build_site(new_process = FALSE)
 
-      - name: Set environment variable $GIT_BRANCH_NAME
-        id: git-branch-name
-        uses: EthanSK/git-branch-name-action@v1
-
-      - name: Deploy to Netlify
-        if: github.event_name == 'push'
-        id: netlify-deploy
-        uses: nwtgck/actions-netlify@v1.1
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
-          publish-dir: 'reference'
-          production-branch: main
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message:
-            'Deploy from GHA: ${{ github.event.head_commit.message }} (${{ github.sha }})'
-          enable-pull-request-comment: false
-          enable-commit-comment: false
-          enable-commit-status: true
-          alias: deploy-preview-${{ env.GIT_BRANCH_NAME }}
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/R/is_ggplot.R
+++ b/R/is_ggplot.R
@@ -70,12 +70,12 @@ fail_if_not_ggplot <- function(
   message = getOption("ggcheck.fail"),
   env = parent.frame()
 ) {
-  if (is_ggplot(p)) {
-    return(invisible(NULL))
-  }
-
   if (inherits(p, ".result")) {
     p <- get(".result", env)
+  }
+
+  if (is_ggplot(p)) {
+    return(invisible(NULL))
   }
 
   if (is.null(message)) {

--- a/R/is_ggplot.R
+++ b/R/is_ggplot.R
@@ -79,10 +79,17 @@ fail_if_not_ggplot <- function(
   }
 
   if (is.null(message)) {
-    message <- paste0(
-      'I expected your code to create a ggplot, ',
-      'but it created an object of class "', class(p)[[1]], '"'
-    )
+    if (inherits(p, "LayerInstance")) {
+      message <- paste0(
+        'I expected your code to create an entire ggplot, ',
+        'but it only created a ggplot layer (class "', class(p)[[1]], '")'
+      )
+    } else {
+      message <- paste0(
+        'I expected your code to create a ggplot, ',
+        'but it created an object of class "', class(p)[[1]], '"'
+      )
+    }
   }
 
   gradethis::fail(message)

--- a/tests/testthat/_snaps/is_ggplot.md
+++ b/tests/testthat/_snaps/is_ggplot.md
@@ -1,0 +1,24 @@
+# fail_if_not_ggplot() within mock_this_exercise()
+
+    Code
+      gradethis::grade_this({
+        fail_if_not_ggplot()
+      })(gradethis::mock_this_exercise(.user_code = "2"))
+    Output
+      <gradethis_graded: [Incorrect]
+        I expected your code to create a ggplot, but it created an object of
+        class "numeric"
+      >
+
+---
+
+    Code
+      gradethis::grade_this({
+        fail_if_not_ggplot()
+      })(gradethis::mock_this_exercise(.user_code = "ggplot2::geom_point()"))
+    Output
+      <gradethis_graded: [Incorrect]
+        I expected your code to create a ggplot, but it created an object of
+        class "LayerInstance"
+      >
+

--- a/tests/testthat/_snaps/is_ggplot.md
+++ b/tests/testthat/_snaps/is_ggplot.md
@@ -18,7 +18,7 @@
       })(gradethis::mock_this_exercise(.user_code = "ggplot2::geom_point()"))
     Output
       <gradethis_graded: [Incorrect]
-        I expected your code to create a ggplot, but it created an object of
-        class "LayerInstance"
+        I expected your code to create an entire ggplot, but it only created
+        a ggplot layer (class "LayerInstance")
       >
 

--- a/tests/testthat/test-is_ggplot.R
+++ b/tests/testthat/test-is_ggplot.R
@@ -33,3 +33,26 @@ test_that("fail_if_not_ggplot", {
   expect_s3_class(fail_if_not_ggplot(p_invalid), "gradethis_graded")
   expect_false(fail_if_not_ggplot(p_invalid)$correct)
 })
+
+test_that("fail_if_not_ggplot() within mock_this_exercise()", {
+  # Should fail
+  expect_snapshot(
+    gradethis::grade_this({
+      fail_if_not_ggplot()
+    })(gradethis::mock_this_exercise(.user_code = "2"))
+  )
+
+  # Should fail
+  expect_snapshot(
+    gradethis::grade_this({
+      fail_if_not_ggplot()
+    })(gradethis::mock_this_exercise(.user_code = "ggplot2::geom_point()"))
+  )
+
+  # Should not fail
+  expect_null(
+    gradethis::grade_this({
+      fail_if_not_ggplot()
+    })(gradethis::mock_this_exercise(.user_code = "ggplot2::ggplot()"))
+  )
+})


### PR DESCRIPTION
``` r
library(ggcheck)
library(ggplot2)
library(gradethis)

# Fails
grade_this({
  fail_if_not_ggplot()
})(mock_this_exercise(.user_code = "2"))
#> <gradethis_graded: [Incorrect]
#>   I expected your code to create a ggplot, but it created an object of
#>   class "numeric"
#> >


# Fails with special message
grade_this({
  fail_if_not_ggplot()
})(mock_this_exercise(.user_code = "geom_point()"))
#> <gradethis_graded: [Incorrect]
#>   I expected your code to create an entire ggplot, but it only created
#>   a ggplot layer (class "LayerInstance")
#> >

# Passes
grade_this({
  fail_if_not_ggplot()
})(mock_this_exercise(.user_code = "ggplot()"))
```

<sup>Created on 2022-02-24 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #32.