### PR TITLE
Allow `uses_mappings()` to find mappings that appear in every layer of the plot

### DIFF
--- a/R/mappings.R
+++ b/R/mappings.R
@@ -72,7 +72,18 @@ get_mappings <- function(p, local_only = FALSE) {
 
 #' @export
 get_mappings.ggplot <- function(p, local_only = FALSE) {
-  p$mapping
+  aes_map <- p$mapping
+
+  if (local_only) {
+    return(aes_map)
+  }
+
+  layer_maps <- purrr::map(p$layers, "mapping")
+  intersection <- intersect_with_attr(layer_maps)
+
+  aes_map <- c(aes_map, intersection)
+  class(aes_map) <- "uneval"
+  aes_map
 }
 
 #' @export

--- a/R/mappings.R
+++ b/R/mappings.R
@@ -79,7 +79,17 @@ get_mappings.ggplot <- function(p, local_only = FALSE) {
   }
 
   layer_maps <- purrr::map(p$layers, "mapping")
+
+  if (length(layer_maps) < 1) {
+    return(global_map)
+  }
+
   layer_names <- purrr::reduce(purrr::map(layer_maps, names), intersect)
+
+  if (length(layer_names) < 1) {
+    return(global_map)
+  }
+
   layer_names <- purrr::set_names(layer_names)
 
   layer_maps_ubiquitous <- purrr::map(layer_names, function(name) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -341,23 +341,16 @@ flatten_dots <- function(...) {
   args
 }
 
-intersect_with_attr <- function(.l, ...) {
-  list <- c(.l, list(...))
-  attr_list <- purrr::map(list, attr_list)
-
-  intersect <- purrr::reduce(attr_list, intersect)
-  indices <- match(intersect, attr_list[[1]])
-  list[[1]][indices]
-}
-
-attr_list <- function(x) {
-  strip_attr <- function(x) {
-    attributes(x) <- NULL
-    x
+all_identical <- function(.l) {
+  if (length(.l) < 2) {
+    return(TRUE)
   }
 
-  list <- purrr::pmap(
-    c(list(strip_attr(x)), attributes(x)),
-    list
-  )
+  for (i in seq_along(.l)[-1]) {
+    if (!identical(.l[[i - 1]], .l[[i]])) {
+      return(FALSE)
+    }
+  }
+
+  TRUE
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -340,3 +340,24 @@ flatten_dots <- function(...) {
   args <- rlang::dots_list(!!!args, .homonyms = "error")
   args
 }
+
+intersect_with_attr <- function(.l, ...) {
+  list <- c(.l, list(...))
+  attr_list <- purrr::map(list, attr_list)
+
+  intersect <- purrr::reduce(attr_list, intersect)
+  indices <- match(intersect, attr_list[[1]])
+  list[[1]][indices]
+}
+
+attr_list <- function(x) {
+  strip_attr <- function(x) {
+    attributes(x) <- NULL
+    x
+  }
+
+  list <- purrr::pmap(
+    c(list(strip_attr(x)), attributes(x)),
+    list
+  )
+}

--- a/tests/testthat/test-mappings.R
+++ b/tests/testthat/test-mappings.R
@@ -15,12 +15,38 @@ p2 <-
   geom_smooth(se = FALSE) +
   labs(title = "TITLE", subtitle = "SUBTITLE", caption = "CAPTION")
 
+p3 <-
+  ggplot(data = mpg, mapping = aes(x = displ, y = hwy)) +
+  geom_point(mapping = aes(color = class, shape = drv)) +
+  geom_smooth(mapping = aes(color = class), se = FALSE, method = lm) +
+  labs(title = "TITLE", subtitle = "SUBTITLE", caption = "CAPTION")
+
 test_that("Identifies global mapping", {
   expect_equal(
     get_mappings(p),
     aes(x = displ, y = hwy),
     ignore_formula_env = TRUE
   )
+})
+
+test_that("Inherit local mappings that appear in all layers", {
+  expect_equal(
+    get_mappings(p3),
+    aes(x = displ, y = hwy, color = class),
+    ignore_formula_env = TRUE
+  )
+
+  expect_equal(
+    get_mappings(p3, local_only = TRUE),
+    aes(x = displ, y = hwy),
+    ignore_formula_env = TRUE
+  )
+
+  expect_true(uses_mappings(p3, aes(x = displ)))
+  expect_true(uses_mappings(p3, aes(x = displ), local_only = TRUE))
+  expect_true(uses_mappings(p3, aes(color = class)))
+  expect_false(uses_mappings(p3, aes(color = class), local_only = TRUE))
+  expect_false(uses_mappings(p3, aes(shape = drv)))
 })
 
 test_that("Checks whether mappings are used globally", {

--- a/tests/testthat/test-mappings.R
+++ b/tests/testthat/test-mappings.R
@@ -16,9 +16,9 @@ p2 <-
   labs(title = "TITLE", subtitle = "SUBTITLE", caption = "CAPTION")
 
 p3 <-
-  ggplot(data = mpg, mapping = aes(x = displ, y = hwy)) +
-  geom_point(mapping = aes(color = class, shape = drv)) +
-  geom_smooth(mapping = aes(color = class), se = FALSE, method = lm) +
+  ggplot(data = mpg, mapping = aes(x = displ)) +
+  geom_point(mapping = aes(y = hwy, color = class, shape = drv)) +
+  geom_smooth(mapping = aes(y = hwy, color = drv), se = FALSE) +
   labs(title = "TITLE", subtitle = "SUBTITLE", caption = "CAPTION")
 
 test_that("Identifies global mapping", {
@@ -32,20 +32,22 @@ test_that("Identifies global mapping", {
 test_that("Inherit local mappings that appear in all layers", {
   expect_equal(
     get_mappings(p3),
-    aes(x = displ, y = hwy, color = class),
+    aes(x = displ, y = hwy),
     ignore_formula_env = TRUE
   )
 
   expect_equal(
     get_mappings(p3, local_only = TRUE),
-    aes(x = displ, y = hwy),
+    aes(x = displ),
     ignore_formula_env = TRUE
   )
 
   expect_true(uses_mappings(p3, aes(x = displ)))
   expect_true(uses_mappings(p3, aes(x = displ), local_only = TRUE))
-  expect_true(uses_mappings(p3, aes(color = class)))
-  expect_false(uses_mappings(p3, aes(color = class), local_only = TRUE))
+  expect_true(uses_mappings(p3, aes(y = hwy)))
+  expect_false(uses_mappings(p3, aes(y = hwy), local_only = TRUE))
+  expect_false(uses_mappings(p3, aes(color = class)))
+  expect_false(uses_mappings(p3, aes(color = drv)))
   expect_false(uses_mappings(p3, aes(shape = drv)))
 })
 

--- a/tests/testthat/test-mappings.R
+++ b/tests/testthat/test-mappings.R
@@ -42,12 +42,16 @@ test_that("Inherit local mappings that appear in all layers", {
     ignore_formula_env = TRUE
   )
 
+  # `x` is mapped globally in `ggplot()`
   expect_true(uses_mappings(p3, aes(x = displ)))
   expect_true(uses_mappings(p3, aes(x = displ), local_only = TRUE))
+  # `y` is mapped locally to the same value in each layer
   expect_true(uses_mappings(p3, aes(y = hwy)))
   expect_false(uses_mappings(p3, aes(y = hwy), local_only = TRUE))
+  # `color` is mapped locally to different values in each layer
   expect_false(uses_mappings(p3, aes(color = class)))
   expect_false(uses_mappings(p3, aes(color = drv)))
+  # `shape` is only mapped in one layer
   expect_false(uses_mappings(p3, aes(shape = drv)))
 })
 


### PR DESCRIPTION
If `local_only = FALSE`, `get_mappings()` and `uses_mappings()` find mappings that appear in `ggplot()` _or_ in every layer of the plot

``` r
library(ggplot2)
library(ggcheck)

p <- ggplot(mtcars, aes(x = wt)) +
  geom_point(aes(y = mpg, group = cyl)) +
  geom_smooth(aes(y = mpg, group = am))

get_mappings(p, local_only = TRUE)
#> Aesthetic mapping: 
#> * `x` -> `wt`
get_mappings(p)
#> Aesthetic mapping: 
#> * `x` -> `wt`
#> * `y` -> `mpg`

uses_mappings(p, aes(x = wt, y = mpg), local_only = TRUE)
#> [1] FALSE
uses_mappings(p, aes(x = wt, y = mpg))
#> [1] TRUE

uses_mappings(p, aes(x = wt, y = mpg, group = cyl))
#> [1] FALSE
```

<sup>Created on 2022-03-17 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #34